### PR TITLE
Fix:  typo in README.md,forgotten file name in mergeConfigFrom method,typo and bug in PasswordHistory.php 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We suggest to use `saveOrFail` to do all the queries in a transaction
 $user->saveOrFail();
 ```
 
-Be careful that chaing the model like below does not fire any model event hence to password change would be recorded behind the scenses.
+Be careful that changing the model like below does not fire any model event hence to password change would be recorded behind the scenes.
 
 ```php
 <?php
@@ -78,16 +78,16 @@ Yeah, the package supports it, visit the config file.
 --------------------
 
 ### :raising_hand: Contributing 
-If you find an issue, or have a better way to do something, feel free to open an issue or a pull request.
-If you use laravel-widgetize in your open source project, create a pull request to provide it's url as a sample application in the README.md file. 
+If you find an issue or have a better way to do something, feel free to open an issue or a pull request.
+If you use laravel-widgetize in your open source project, create a pull request to provide its URL as a sample application in the README.md file. 
 
 
 ### :exclamation: Security
-If you discover any security related issues, please use the `security tab` instead of using the issue tracker.
+If you discover any security-related issues, please use the `security tab` instead of using the issue tracker.
 
 
 ### :star: Your Stars Make Us Do More :star:
-As always if you found this package useful and you want to encourage us to maintain and work on it. Just press the star button to declare your willing.
+As always if you found this package useful and you want to encourage us to maintain and work on it. Just press the star button to declare your willingness.
 
 
 
@@ -104,7 +104,7 @@ As always if you found this package useful and you want to encourage us to maint
 
 ### Laravel HeyMan
 
-:gem: It allows to write expressive code to authorize, validate and authenticate.
+:gem: It allows us to write expressive code to authorize, validate and authenticate.
 
 - https://github.com/imanghafoori1/laravel-heyman
 
@@ -114,7 +114,7 @@ As always if you found this package useful and you want to encourage us to maint
 ### Laravel Terminator
 
 
- :gem: A minimal yet powerful package to give you opportunity to refactor your controllers.
+ :gem: A minimal yet powerful package to give you the opportunity to refactor your controllers.
 
 - https://github.com/imanghafoori1/laravel-terminator
 
@@ -123,7 +123,7 @@ As always if you found this package useful and you want to encourage us to maint
 
 ### Laravel AnyPass
 
-:gem: It allows you login with any password in local environment only.
+:gem: It allows you to login with any password in the local environment only.
 
 - https://github.com/imanghafoori1/laravel-anypass
 
@@ -140,7 +140,7 @@ As always if you found this package useful and you want to encourage us to maint
 
 ### 🍌 Reward me a banana 🍌
 
-so that I will have energy to start the next package for you.
+so that I will have the energy to start the next package for you.
 
 - Dodge Coin: DJEZr6GJ4Vx37LGF3zSng711AFZzmJTouN
 - LiteCoin: ltc1q82gnjkend684c5hvprg95fnja0ktjdfrhcu4c4

--- a/src/Database/PasswordHistory.php
+++ b/src/Database/PasswordHistory.php
@@ -6,16 +6,13 @@ use Illuminate\Database\Eloquent\Model;
 
 class PasswordHistory extends Model
 {
-    public function __construct()
+    protected $table;
+    protected $fillable = ['user_id','password', 'guard'];
+
+    public function __construct(array $attributes = [])
     {
         $this->table = config('password_history.table_name');
-        parent::__construct();
+        parent::__construct($attributes);
     }
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array
-     */
-    protected $fillable = ['password', 'guard'];
 }

--- a/src/PasswordHistoryServiceProvider.php
+++ b/src/PasswordHistoryServiceProvider.php
@@ -11,7 +11,7 @@ class PasswordHistoryServiceProvider extends ServiceProvider
     public function register()
     {
         PasswordHistoryManager::shouldProxyTo(PasswordHistory::class);
-        $this->mergeConfigFrom(__DIR__ .'/config', 'password_history');
+        $this->mergeConfigFrom(__DIR__ .'/config/password_history.php', 'password_history');
     }
     public function boot()
     {


### PR DESCRIPTION
about **PasswordHistoryServiceProvider.php**
forgotten config file name in mergeConfigFrom method in PasswordHistoryServiceProvider which causes errors in  package:discover artisan command and whole application fixed

**PasswordHistory.php**
forgotten column 'user_id' in $fillable array added
variable $table defined and some edits in __construct() method which was needed to insert records in password_histories table performed (due to not sending any attributes to the model I got default value error)

**README.md**
and some typos and grammar mistakes in README.md fixed(honestly mostly I used [Grammarly](http://www.grammarly.com/) !)

thanks
