### PR TITLE
fix validator return when no previous entries found

### DIFF
--- a/src/PasswordHistory.php
+++ b/src/PasswordHistory.php
@@ -33,7 +33,7 @@ class PasswordHistory
 
     function isInHistoryOfUser($password, $user, $depth = null)
     {
-        return $this->isInHistory($password, $user->getKey(), $depth, $this->getGuard($user));
+        return $this->isInHistory($password, $user->getKey(), $depth, $this->getGuard($user))->getOr(false);
     }
 
     function isInHistory($password, $userId, $depth = null, $guard = '')


### PR DESCRIPTION
isInHistoryOfUser() always returned an object or always true, changed to return false if nullable() is null