### PR TITLE
Bug Fix 

### DIFF
--- a/src/PasswordHistory.php
+++ b/src/PasswordHistory.php
@@ -43,11 +43,11 @@ class PasswordHistory
 
         foreach ($histories as $history) {
             if (Hash::check($password, $history->password)) {
-                return nullable($history);
+                return true;
             }
         }
 
-        return nullable();
+        return false;
     }
 
     function latestChangeDate($user)

--- a/tests/Integration/PasswordHistoryTest.php
+++ b/tests/Integration/PasswordHistoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Imanghafoori\PasswordHistoryTests\Feature;
+namespace Imanghafoori\PasswordHistoryTests\Integration;
 
 use Imanghafoori\PasswordHistory\Database\PasswordHistory;
 use Imanghafoori\PasswordHistoryTests\Requirements\Models\User;
@@ -8,7 +8,6 @@ use Imanghafoori\PasswordHistoryTests\TestCase;
 
 class PasswordHistoryTest extends TestCase
 {
-
     /** @test */
     public function history_is_stored_when_creating_new_user()
     {
@@ -46,12 +45,6 @@ class PasswordHistoryTest extends TestCase
         $user->save();
 
         $this->assertEquals(1, PasswordHistory::count());
-
-        $user->password = $user->password;
-
-        $user->save();
-
-        $this->assertEquals(1, PasswordHistory::count());
     }
 
     /** @test */
@@ -64,8 +57,22 @@ class PasswordHistoryTest extends TestCase
         $this->assertEquals(1, PasswordHistory::count());
     }
 
-    private function createUser()
+    /** @test */
+    public function history_is_not_being_recorded_if_new_password_used_before()
     {
-        return factory(User::class)->create();
+        $password = '111111';
+
+        $user = $this->createUser(['password' => $password]);
+
+        $user->password = $password;
+
+        $user->save();
+
+        $this->assertEquals(1, PasswordHistory::count());
+    }
+
+    private function createUser($attributes = [])
+    {
+        return factory(User::class)->create($attributes);
     }
 }

--- a/tests/Integration/PasswordHistoryTest.php
+++ b/tests/Integration/PasswordHistoryTest.php
@@ -70,9 +70,4 @@ class PasswordHistoryTest extends TestCase
 
         $this->assertEquals(1, PasswordHistory::count());
     }
-
-    private function createUser($attributes = [])
-    {
-        return factory(User::class)->create($attributes);
-    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Imanghafoori\PasswordHistoryTests;
 
 use Imanghafoori\PasswordHistory\PasswordHistoryServiceProvider;
+use Imanghafoori\PasswordHistoryTests\Requirements\Models\User;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -17,5 +18,10 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $this->loadMigrationsFrom(__DIR__.'/../src/Database/migrations');
         $this->loadMigrationsFrom(__DIR__.'/Requirements/database/migrations');
         $this->withFactories(__DIR__.'/Requirements/database/factories');
+    }
+
+    protected function createUser($attributes = [])
+    {
+        return factory(User::class)->create($attributes);
     }
 }

--- a/tests/Unit/ValidationRuleTest.php
+++ b/tests/Unit/ValidationRuleTest.php
@@ -25,7 +25,7 @@ class ValidationRuleTest extends TestCase
     }
 
     /** @test */
-    public function validation_wont_pass_when_password_not_used_before()
+    public function validation_wont_pass_when_password_used_before()
     {
         $password = '111111';
 

--- a/tests/Unit/ValidationRuleTest.php
+++ b/tests/Unit/ValidationRuleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Imanghafoori\PasswordHistoryTests\Integration;
+
+use Illuminate\Support\Facades\Hash;
+use Imanghafoori\PasswordHistory\Rules\NotBeInPasswordHistory;
+use Imanghafoori\PasswordHistoryTests\TestCase;
+
+class ValidationRuleTest extends TestCase
+{
+    /** @test */
+    public function validation_passes_when_password_not_used_before()
+    {
+        $user = $this->createUser(['password' => Hash::make('111111')]);
+
+        $rules = [
+            'password' => [NotBeInPasswordHistory::ofUser($user)]
+        ];
+
+        $data = ['password' => '222222'];
+
+        $validator = app('validator')->make($data, $rules);
+
+        $this->assertTrue($validator->passes());
+    }
+
+    /** @test */
+    public function validation_wont_pass_when_password_not_used_before()
+    {
+        $password = '111111';
+
+        $user = $this->createUser(['password' => Hash::make($password)]);
+
+        $rules = [
+            'password' => [NotBeInPasswordHistory::ofUser($user)]
+        ];
+
+        $data = ['password' => $password];
+
+        $validator = app('validator')->make($data, $rules);
+
+        $this->assertFalse($validator->passes());
+    }
+}


### PR DESCRIPTION
When checking user's password history,  Line 38 (from below permalink), Doesn't resolve an stable boolean. 

https://github.com/imanghafoori1/laravel-password-history/blob/2afdadc291cdaea1152e6dd6b63a8075a3881d1f/src/Rules/NotBeInPasswordHistory.php#L34-L39

Have a look at unit tests. 

(I hope I detected the problem correctly).