### PR TITLE
Update PasswordHistoryServiceProvider.php

### DIFF
--- a/src/PasswordHistoryServiceProvider.php
+++ b/src/PasswordHistoryServiceProvider.php
@@ -42,9 +42,9 @@ class PasswordHistoryServiceProvider extends ServiceProvider
     {
         $configFile = __DIR__.'/config/password_history.php';
 
-        if($this->app->runningUnitTests()) {
+        /*if($this->app->runningUnitTests()) {
             $configFile = __DIR__.'/../tests/Requirements/config/password_history.php';
-        }
+        }*/
 
         $this->mergeConfigFrom($configFile, 'password_history');
     }


### PR DESCRIPTION
Removed reference to nonexistent directory - `vendor:publish` always copies the configuration file in _/config/password_history.php_ regardless of the application running unit tests or not.